### PR TITLE
Corrected variable name in Test-UserObject

### DIFF
--- a/Hawk.psm1
+++ b/Hawk.psm1
@@ -1001,7 +1001,7 @@ Function Test-UserObject {
     }
     # Case 3 - Array of objects
     # Validate that at least one object in the array contains a UserPrincipalName Property
-    elseif ([bool](get-member -inputobject $a[0] -name UserPrincipalName -MemberType Properties)) {
+    elseif ([bool](get-member -inputobject $ToTest[0] -name UserPrincipalName -MemberType Properties)) {
         Return $ToTest
     }
     else {


### PR DESCRIPTION
Replaced undefined variable name `$a` with `$ToTest` to permit the use of an array of objects as input.

Looks like the editor also changed a line ending at the end of the file.