### PR TITLE
Fixing "String was not recognized as a valid DateTime."

### DIFF
--- a/Hawk.psm1
+++ b/Hawk.psm1
@@ -260,7 +260,7 @@ Function Get-AllUnifiedAuditLogEntry {
     [string]$cmd = $null
 	
     # build our search command to execute
-    $cmd = $UnifiedSearch + " -StartDate `'" + $StartDate.ToShortDateString() + "`' -EndDate `'" + $EndDate.ToShortDateString() + "`' -SessionCommand ReturnLargeSet -resultsize 1000 -sessionid " + (Get-Date -UFormat %H%M%S)
+    $cmd = $UnifiedSearch + " -StartDate `'" + $StartDate.toString("MM/dd/yyyy") + "`' -EndDate `'" + $EndDate.toString("MM/dd/yyyy") + "`' -SessionCommand ReturnLargeSet -resultsize 1000 -sessionid " + (Get-Date -UFormat %H%M%S)
     Out-LogFile ("Running Unified Audit Log Search")
     Out-Logfile $cmd
 


### PR DESCRIPTION
This seems to fix the issue with DateTime in Unified Audit Log Search. So it will render the datetime in a en-US cultured format always.  
  
I found this issue on it - #27