### PR TITLE
Resolve EndDate issue #45 & update UAL enddate to include HHmmss

### DIFF
--- a/General/Initialize-HawkGlobalObject.ps1
+++ b/General/Initialize-HawkGlobalObject.ps1
@@ -304,13 +304,13 @@ Function Initialize-HawkGlobalObject {
                 # if we have a null entry (just hit enter) then set startread to the default of 90
                 if ([string]::IsNullOrEmpty($EndRead)) {
                     Write-Information ("Setting End Date to Today")
-                    [DateTime]$EndDate = ((Get-Date).AddDays(1)).Date
+                    [DateTime]$EndDate = Get-date -Format ("dd/MM/yyyy HH:mm:ss").Date
                 }
                 else {
                     # Calculate our startdate setting it to midnight
                     Write-Information ("Calculating End Date from current date minus " + $EndRead + " days.")
                     # Subtract 1 from the EndRead entry so that we get one day less for the purpose of how searching works with times
-                    [DateTime]$EndDate = ((Get-Date).AddDays( - ($EndRead - 1))).Date
+                    [DateTime]$EndDate = Get-date -Format ("dd/MM/yyyy HH:mm:ss").Date
                 }
 
                 # Validate that the start date is further back in time than the end date

--- a/Hawk.psm1
+++ b/Hawk.psm1
@@ -260,7 +260,7 @@ Function Get-AllUnifiedAuditLogEntry {
     [string]$cmd = $null
 	
     # build our search command to execute
-    $cmd = $UnifiedSearch + " -StartDate `'" + $StartDate.ToShortDateString() + "`' -EndDate `'" + $EndDate.ToShortDateString() + "`' -SessionCommand ReturnLargeSet -resultsize 1000 -sessionid " + (Get-Date -UFormat %H%M%S)
+    $cmd = $UnifiedSearch + " -StartDate `'" + $StartDate.toString("MM/dd/yyyy") + "`' -EndDate `'" + $EndDate.toString("MM/dd/yyyy HH:mm:ss") + "`' -SessionCommand ReturnLargeSet -resultsize 1000 -sessionid " + (Get-Date -UFormat %H%M%S)
     Out-LogFile ("Running Unified Audit Log Search")
     Out-Logfile $cmd
 


### PR DESCRIPTION
Modification to Initialize-HawkGlobalObject.ps1 
- Change EndDate to be local date in dd/mm/yy HH:mm:ss for search enddate's to work correctly and ensure all logs are collected up to and including when the module is being executed. 

Modify Hawk.psm1
-  Include previous change for #45 
- Add HHmmss to UAL search endtime to ensure all logs are captured if enddate of "today" is set in initial config.