### PR TITLE
Changed $RangeEnd to datetime.

### DIFF
--- a/Hawk/functions/User/Get-HawkUserMailboxAuditing.ps1
+++ b/Hawk/functions/User/Get-HawkUserMailboxAuditing.ps1
@@ -51,8 +51,11 @@
         [datetime]$RangeStart = $StartDate
 
         do {
-            # Get the end of the Range we are going to gather data for
-            [string]$RangeEnd =[datetime]::parse($RangeStart, [CultureInfo]::CreateSpecificCulture("en-US")).AddDays(5).toString("MM/dd/yyyy")
+            # Get the end of the Range we are going to gather data for            
+            [datetime] $RangeEnd = $RangeStart.AddDays(5)
+            if ($RangeEnd -gt $EndDate) {
+                $RangeEnd = $EndDate
+            }
 
             # Do the actual search
             Out-LogFile ("Searching Range " + [string]$RangeStart + " To " + [string]$RangeEnd)


### PR DESCRIPTION
This addresses a bug
which can cause the script to terminate prematurely if
the start date and end date are in different years.  This was
a result of $RangeEnd being declared as a string type, which forces an implicit
conversion of $RangeStart to datetime in the while loop's conditional clause, which in
turn forces a lexical rather than numeric comparison.

Also, added an if statement to prevent the final 5 day pull from going beyond $EndDate.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B


## Checklist:

- [x] My code follows the style guidelines of Hawk
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
