### PR TITLE
Fix encoding of outputs from the Export-Csv cmdlet with UTF8(BOM). #81

### DIFF
--- a/Hawk/internal/functions/Out-MultipleFileType.ps1
+++ b/Hawk/internal/functions/Out-MultipleFileType.ps1
@@ -135,13 +135,13 @@ Function Out-MultipleFileType {
                     Out-LogFile ("Appending Data to " + $filename)
 
                     # Write it out to csv making sture to append
-                    $AllObject | Export-Csv $filename -NoTypeInformation -Append
+                    $AllObject | Export-Csv $filename -NoTypeInformation -Append -Encoding UTF8
                 }
 
                 # Otherwise overwrite
                 else {
                     Out-LogFile ("Writing Data to " + $filename)
-                    $AllObject | Export-Csv $filename -NoTypeInformation
+                    $AllObject | Export-Csv $filename -NoTypeInformation -Encoding UTF8
                 }
 
                 # If notice is set we need to write the file name to _Investigate.txt


### PR DESCRIPTION
## Description
In order to fix issue #81,
I added encoding specifying option to the Export-Csv cmdlet in the [Out-MultipleFileType.ps1](https://github.com/T0pCyber/hawk/blob/011ab828a35063cbd145efbf98eeac1d8d0e17fe/Hawk/internal/functions/Out-MultipleFileType.ps1).

Only two line changes.

The encoding of CSV files is changed to UTF-8(BOM) from default ASCII.
The reason it is UTF-8 (BOM) instead of UTF-16 is that it works well with Excel. (Excel can't correctly open UTF-16 CSV with a double click. It ignores comma delimiter.)

This fix enables HAWK to output CSV files containing the non-ASCII character.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Import HAWK local code and execute the Get-HawkUserInvestigation command.
  - Uninstall hawk installed locally `> Uninstall-Module -name Hawk`
  - Hit import command. `> Import-Module hawk/HAWK/Hawk.psm1`
  - Hit the HAWK command. (Don't update to the latest online version.) `> Get-HawkUserInvestigation <user mail address>`
  - Look at output CSV files. They are encoded with UTF-16LE with BOM, not ASCII.


## Checklist:

- [x] My code follows the style guidelines of Hawk -> Maybe
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas -> N/A
- [ ] I have made corresponding changes to the documentation -> N/A
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings