### PR TITLE
feat: Update Entra ID terminology and object identifiers

### DIFF
--- a/Hawk/Hawk.psd1
+++ b/Hawk/Hawk.psd1
@@ -3,7 +3,7 @@
 	RootModule         = 'Hawk.psm1'
 
 	# Version number of this module.
-	ModuleVersion      = '3.1.2'
+	ModuleVersion      = '3.2.3'
 
 	# ID used to uniquely identify this module
 	GUID               = '1f6b6b91-79c4-4edf-83a1-66d2dc8c3d85'
@@ -72,7 +72,7 @@
 	'Get-HawkUserAutoReply',
 	'Get-HawkUserMessageTrace',
 	'Get-HawkUserMobileDevice',
-	'Get-HawkTenantAZAdmin',
+	'Get-HawkTenantEntraIDAdmin',
 	'Get-HawkTenantEXOAdmins',
 	'Get-HawkTenantMailItemsAccessed',
 	'Get-HawkTenantAppAndSPNCredentialDetail',

--- a/Hawk/changelog.md
+++ b/Hawk/changelog.md
@@ -54,3 +54,24 @@
 - Added logging filepath checking the Start-HawkUserInvestigation.ps1
 - Updated Get-HawkTenantAZAdmins.ps1. Removed AzureAD module. Added MS Graph cmdlets.
 - Updated contact email
+
+## 3.1.2 (2024-12-01)
+
+- Removed Robust Cloud Command from build as it was not being used in the code base anymore
+- Updated PowerShell API key in GitHub to fix build.yml issue where the Hawk would not publish to gallery on merge to main
+
+## 3.2.3 (2024-12-09)
+
+- **Migration to Microsoft Graph**: Replaced all AzureAD functionality with Microsoft Graph commands, including updates to functions like `Get-HawkTenantAppAndSPNCredentialDetails` (now using `Get-MgServicePrincipal` and `Get-MgApplication`).
+
+- **Directory Role Management**: Updated `Get-HawkTenantAZAdmins` to use Microsoft Graph (`Get-MgRoleDefinition` and `Get-MgRoleAssignment`), renamed to `Get-HawkTenantEntraIDAdmin`, and enhanced output for better role tracking.
+
+- **Consent Grant Updates**: Migrated `Get-HawkTenantConsentGrant` to Graph commands (`Get-MgOauth2PermissionGrant` and `Get-MgServicePrincipalAppRoleAssignment`), ensuring consistent output and backward compatibility.
+
+- **Removed AzureAD Dependencies**: Eliminated AzureAD references in the Hawk.psd1 manifest and removed the deprecated `Test-AzureADConnection.ps1`. Updated manifest to rely solely on Microsoft Graph modules (v2.25.0).
+
+- **Simplified Authentication**: Streamlined Graph API connections by removing unnecessary commands like `Select-MgProfile` and improving `Test-GraphConnection` for default behaviors.
+
+- **Improved Logging and Naming**: Standardized log outputs (e.g., `AzureADUsers` to `EntraIDUsers`) and aligned function outputs with updated naming conventions.
+
+- This release completes the migration to Microsoft Graph, fully deprecating AzureAD and aligning Hawk with modern Microsoft standards.

--- a/Hawk/functions/Tenant/Get-HawkTenantAppAndSPNCredentialDetail.ps1
+++ b/Hawk/functions/Tenant/Get-HawkTenantAppAndSPNCredentialDetail.ps1
@@ -40,10 +40,10 @@
         $spnResults = @()
         $appResults = @()
 
-        Out-LogFile "Collecting Azure AD Service Principals"
+        Out-LogFile "Collecting Entra ID Service Principals"
         try {
             $spns = Get-MgServicePrincipal -All | Sort-Object -Property DisplayName
-            Out-LogFile "Collecting Azure AD Registered Applications"
+            Out-LogFile "Collecting Entra ID Registered Applications"
             $apps = Get-MgApplication -All | Sort-Object -Property DisplayName
         }
         catch {

--- a/Hawk/functions/Tenant/Start-HawkTenantInvestigation.ps1
+++ b/Hawk/functions/Tenant/Start-HawkTenantInvestigation.ps1
@@ -86,9 +86,9 @@
 		Get-HawkTenantConsentGrant
 	}
 
-	if ($PSCmdlet.ShouldProcess("Azure Admins", "Get Azure admin list")) {
-		Out-LogFile "Running Get-HawkTenantAZAdmin" -action
-		Get-HawkTenantAZAdmin
+	if ($PSCmdlet.ShouldProcess("Azure Admins", "Get Entra ID admin list")) {
+		Out-LogFile "Running Get-HawkTenantEntraIDAdmin" -action
+		Get-HawkTenantEntraIDAdmin
 	}
 
 	if ($PSCmdlet.ShouldProcess("App and SPN Credentials", "Get credential details")) {


### PR DESCRIPTION
- Replace 'Azure AD' terminology with 'Microsoft Entra ID' to align with Microsoft's rebranding.
- Rename output file from AzureADAdministrators to EntraIDAdministrators.
- Change MemberId property to ObjectId for better accuracy with Graph API terminology.
- Add detailed code comments to improve maintainability.
- Updated Hawk.psd1 to version 3.2.3.
- Updated changelog to reflect release 3.2.3 changes.

