### PR TITLE
Implemented High Risk Permissions Identification

### DIFF
--- a/Hawk/functions/Tenant/Get-HawkTenantConsentGrant.ps1
+++ b/Hawk/functions/Tenant/Get-HawkTenantConsentGrant.ps1
@@ -25,31 +25,84 @@
     [CmdletBinding()]
     param()
 
-    Out-LogFile "Gathering OAuth / Application Grants" -Action
+    Out-LogFile "Gathering OAuth / Application Grants"
 
     Test-GraphConnection
 
     # Gather the grants using the internal Graph-based implementation
     [array]$Grants = Get-AzureADPSPermission -ShowProgress
+    
+    # Create new Property for Consent_Grants output table
+    $Grants | Add-Member -NotePropertyName Flag -NotePropertyValue ""
+    
     [bool]$flag = $false
 
+    # Define list of Extremely Dangerous grants
+    [array]$ExtremelyDangerousGrants = "AppRoleAssignment.ReadWrite.All", "RoleManagementAlert.ReadWrite.Directory"
+
+    # Define list of High Risk grants
+    [array]$HighRiskGrants = "BitlockerKey.Read.All", "Chat.*", "Directory.ReadWrite.All", "eDiscovery.*", "Files.*", 
+                            "MailboxSettings.ReadWrite", "Mail.ReadWrite", "Mail.Send", "Sites.*", "User.*"
+
     # Search the Grants for the listed bad grants that we can detect
+    #Flag broad-scope grants
+    foreach($grant in $Grants) {
+        $Grants | ForEach-Object -Process {
+            if($_.ConsentType -contains 'AllPrincipals' -or $_.Permission -match 'all') {
+                $_.Flag = "Broad-Scope Grant"
+            }
+        }
+    }
+
     if ($Grants.ConsentType -contains 'AllPrincipals') {
         Out-LogFile "Found at least one 'AllPrincipals' Grant" -notice
         $flag = $true
     }
-    if ([bool]($Grants.Permission -match 'all')) {
+
+	if ([bool]($Grants.Permission -match 'all')) {
         Out-LogFile "Found at least one 'All' Grant" -notice
+        $flag = $true
+    }
+    
+    #Flag Extremely Dangerous grants; if a grant is both broad-scope and E.D., flag as E.D.
+    [int]$EDGrantCount = 0
+    foreach($grant in $ExtremelyDangerousGrants) {
+        $Grants | ForEach-Object -Process {
+            if($_.Permission -cmatch $grant){
+                $_.Flag = "Extremely Dangerous"
+                $EDGrantCount += 1
+            }
+        }
+    }
+
+    if ($EDGrantCount -gt 0) {
+        Out-LogFile "Found at least one Extremely Dangerous Grant" -notice
+        $flag = $true
+    }
+    
+    #Flag High Risk grants; if a grant is both broad-scope and H.R., flag as H.R.
+    [int]$HRGrantCount = 0
+    foreach($grant in $HighRiskGrants) {
+        $Grants | ForEach-Object -Process {
+            if($_.Permission -cmatch $grant){
+                $_.Flag = "High Risk"
+                $HRGrantCount += 1
+            }
+        }
+    }
+
+    if ($HRGrantCount -gt 0) {
+        Out-LogFile "Found at least one High Risk Grant" -notice
         $flag = $true
     }
 
     if ($flag) {
-        Out-LogFile 'Review the information at the following link to understand these results' -Information
-        Out-LogFile 'https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants' -Information
+        Out-LogFile 'Review the information at the following link to understand these results' -notice
+        Out-LogFile 'https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants' -notice
     }
     else {
-        Out-LogFile "To review this data follow:" -Information
-        Out-LogFile "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants" -Information
+        Out-LogFile "To review this data follow:"
+        Out-LogFile "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/detect-and-remediate-illicit-consent-grants"
     }
 
     $Grants | Out-MultipleFileType -FilePrefix "Consent_Grants" -csv -json


### PR DESCRIPTION
# Pull Request Template

## Description

Addressing Ticket #168, I've added the identification and flagging of both High Risk and Extremely Dangerous grants along with the broad-scope grants that were previously reported on.  Additional Notices within Hawk logs were included and an additional Flag property was added to the output files to highlight these grants to be investigated by the analyst/user.

Fixes: 3
- Added additional notices to the Hawk log file if High Risk or Extremely Dangerous grants were detected
- Added 'Flag' property to the output Consent_Grants.csv/json for reporting these risky grants
- Added 'Broad-Scope' flag for 'AllPrincipals' consent type and 'all'-type permissions

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Individually ran Get-HawkTenantConsentGrants following changes and verified desired output within Hawk logs and Consent-Grants.csv/json files


## Checklist:

- [X] My code follows the style guidelines of Hawk
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
