### PR TITLE
feature/168: Made edits following prev pull request

### DIFF
--- a/Hawk/functions/Tenant/Get-HawkTenantConsentGrant.ps1
+++ b/Hawk/functions/Tenant/Get-HawkTenantConsentGrant.ps1
@@ -31,15 +31,64 @@
 
     # Gather the grants using the internal Graph-based implementation
     [array]$Grants = Get-AzureADPSPermission -ShowProgress
+    
+    # Create new Property for Consent_Grants output table
+    $Grants | Add-Member -NotePropertyName Flag -NotePropertyValue ""
+    
     [bool]$flag = $false
 
+    # Define list of Extremely Dangerous grants
+    [array]$ExtremelyDangerousGrants = "^AppRoleAssignment\.ReadWrite\.All$", "^RoleManagement\.ReadWrite\.Directory$"
+
+    # Define list of High Risk grants
+    [array]$HighRiskGrants = "^BitlockerKey\.Read\.All$", "^Chat\.", "^Directory\.ReadWrite\.All$", "^eDiscovery\.", 
+        "^Files\.", "^MailboxSettings\.ReadWrite$", "^Mail\.ReadWrite$", "^Mail\.Send$", "^Sites\.", "^User\."
+
     # Search the Grants for the listed bad grants that we can detect
-    if ($Grants.ConsentType -contains 'AllPrincipals') {
-        Out-LogFile "Found at least one 'AllPrincipals' Grant" -notice
+
+    #Flag broad-scope grants
+    [int]$BroadGrantCount = 0
+    $Grants | ForEach-Object -Process {
+        if($_.ConsentType -contains 'AllPrincipals' -or $_.Permission -match 'all') {
+            $_.Flag = "Broad-Scope Grant"
+            $BroadGrantCount += 1
+        }
+    }
+
+    if($BroadGrantCount -gt 0) {
+        Out-LogFile "Found $BroadGrantCount Broad-Scope ('AllPrincipals' or '*.All') Grant(s)" -notice
         $flag = $true
     }
-    if ([bool]($Grants.Permission -match 'all')) {
-        Out-LogFile "Found at least one 'All' Grant" -notice
+    
+    #Flag Extremely Dangerous grants; if a grant is both broad-scope and E.D., flag as E.D.
+    [int]$EDGrantCount = 0
+    foreach($grant in $ExtremelyDangerousGrants) {
+        $Grants | ForEach-Object -Process {
+            if($_.Permission -match $grant){
+                $_.Flag = "Extremely Dangerous"
+                $EDGrantCount += 1
+            }
+        }
+    }
+
+    if ($EDGrantCount -gt 0) {
+        Out-LogFile "Found $EDGrantCount Extremely Dangerous Grant(s)" -notice
+        $flag = $true
+    }
+    
+    #Flag High Risk grants; if a grant is both broad-scope and H.R., flag as H.R.
+    [int]$HRGrantCount = 0
+    foreach($grant in $HighRiskGrants) {
+        $Grants | ForEach-Object -Process {
+            if($_.Permission -match $grant){
+                $_.Flag = "High Risk"
+                $HRGrantCount += 1
+            }
+        }
+    }
+
+    if ($HRGrantCount -gt 0) {
+        Out-LogFile "Found $HRGrantCount High Risk Grant(s)" -notice
         $flag = $true
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Addressing fixes suggested following previous pull request for feature #168.  

Fixes
- Adjusted string matching to ensure only specified grants are identified as High Risk/Extremely Dangerous
- Now flagging broad-scope grants in output csv/json files
- Log now reports number of each risky grant found

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Individually tested Get-HawkTenantConsentGrant function and confirmed desired output


## Checklist:

- [X] My code follows the style guidelines of Hawk
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
