### PR TITLE
feature/233: Added User-specific audit for mailitems accessed

### DIFF
--- a/Hawk/functions/User/Get-HawkMailItemsAccessed.ps1
+++ b/Hawk/functions/User/Get-HawkMailItemsAccessed.ps1
@@ -1,0 +1,62 @@
+Function Get-HawkMailItemsAccessed {
+<#
+.SYNOPSIS
+    This will export MailboxItemsAccessed operations from the Unified Audit Log (UAL). Must be connected to Exchange Online
+    using the Connect-EXO or Connect-ExchangeOnline module. M365 E5 or G5 license is required for this function to work.
+    This telemetry will ONLY be availabe if Advanced Auditing is enabled for the M365 user.
+.DESCRIPTION
+    Recent attacker activities have illuminated the use of the Graph API to read user mailbox contents. This will export
+    logs that will be present if the attacker is using the Graph API for such actions. Note: NOT all graph API actions against
+    a mailbox are malicious. Review the results of this function and look for suspicious access of mailbox items associated
+    with a specific user.
+.PARAMETER UserIDs
+    Specific user(s) to be investigated
+.EXAMPLE
+    Get-HawkMailItemsAccessed -UserIDs bsmith@contoso.com
+    Gets MailItemsAccess from Unified Audit Log (UAL) that corresponds to the User ID that is provided
+.OUTPUTS
+    MailItemsAccessed.csv
+
+.LINK
+    https://www.microsoft.com/security/blog/2020/12/21/advice-for-incident-responders-on-recovery-from-systemic-identity-compromises/
+
+.NOTES
+    "Operation Properties" and "Folders" will return "System.Object" as they are nested JSON within the AuditData field.
+    You will need to conduct individual log pull and review via PowerShell or other SIEM to determine values
+    for those fields.
+#>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]$UserIDs
+    )
+
+    BEGIN {
+        # Check if Hawk object exists and is fully initialized
+        if (Test-HawkGlobalObject) {
+            Initialize-HawkGlobalObject
+        }
+        Out-LogFile "Starting Unified Audit Log (UAL) search for 'MailItemsAccessed'" -Action
+    }#End Begin
+
+    PROCESS {
+        $curr_idx = 0
+        foreach($user in $UserIDs) {
+            if($curr_idx -eq 0) {
+                $UserList = $user
+            }else {
+                $UserList = "$UserList, $user"
+            }
+            $curr_idx += 1
+        }
+        $MailboxItemsAccessed = Get-AllUnifiedAuditLogEntry -UnifiedSearch ("Search-UnifiedAuditLog -Operations 'MailItemsAccessed' -UserIds $UserList")
+
+        $MailboxItemsAccessed | Select-Object -ExpandProperty AuditData | Convertfrom-Json | Out-MultipleFileType -FilePrefix "MailItemsAccessed" -csv -json
+        
+    }#End Process
+
+    END{
+        Out-Logfile "Completed exporting MailItemsAccessed logs" -Information
+    }#End End
+
+}

--- a/Hawk/functions/User/Start-HawkUserInvestigation.ps1
+++ b/Hawk/functions/User/Start-HawkUserInvestigation.ps1
@@ -112,6 +112,11 @@
 					Out-LogFile "Running Get-HawkUserMessageTrace" -Action
 					Get-HawkUserMessageTrace -User $User
 				}
+
+				if ($PSCmdlet.ShouldProcess("Running Get-HawkMailItemsAccessed for $User")) {
+					Out-LogFile "Running Get-HawkMailItemsAccessed" -Action
+					Get-HawkMailItemsAccessed -UserIDs $User
+				}
 	
 				if ($PSCmdlet.ShouldProcess("Running Get-HawkUserMobileDevice for $User")) {
 					Out-LogFile "Running Get-HawkUserMobileDevice" -Action


### PR DESCRIPTION
# Pull Request Template

## Description

Created new function Get-HawkMailItemsAccessed to be call during user-specific investigations.  When calling this function, the user is able to utilize the $UserIDs parameter to either obtain an audit for a single user or multiple users.  This function was also added to the Start-HawkUserInvestigation function.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Individually tested Get-HawkMailItemsAccessed and confirmed expected output


## Checklist:

- [X] My code follows the style guidelines of Hawk
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
