### PR TITLE
feature/234: Added check to verify exchange operation enabled for audit.

### DIFF
--- a/Hawk/Hawk.psd1
+++ b/Hawk/Hawk.psd1
@@ -84,6 +84,7 @@
 	'Get-HawkTenantEXOAdmin',
 	'Get-HawkTenantMailItemsAccessed',
 	'Get-HawkUserMailItemsAccessed',
+	'Get-HawkUserExchangeSearchQuery',
 	'Get-HawkTenantAppAndSPNCredentialDetail',
 	'Get-HawkTenantEntraIDUser',
 	'Get-HawkTenantDomainActivity',

--- a/Hawk/changelog.md
+++ b/Hawk/changelog.md
@@ -96,4 +96,6 @@
 - Added functionality to expand detect M365 license type to determine max log retention time
 - Added ability to expand search up to 365 days
 - Added search of mail items accessed to the User Investigation (Get-HawkUserMailItemsAccessed)
+- Added search of Exchange Search Queries to the User Investigation (Get-HawkUserExchangeSearchQuery)
+- Implemented check to verify that an Exchange operation is enabled for auditing before attempting to pull logs
 

--- a/Hawk/functions/User/Get-HawkUserExchangeSearchQuery.ps1
+++ b/Hawk/functions/User/Get-HawkUserExchangeSearchQuery.ps1
@@ -1,0 +1,95 @@
+Function Get-HawkUserExchangeSearchQuery {
+    <#
+    .SYNOPSIS
+        This will export SearchQueryInitiatedExchange operations from the Unified Audit Log (UAL). Must be connected to Exchange Online
+        using the Connect-EXO or Connect-ExchangeOnline module. M365 E5 or G5 license is required for this function to work.
+        This telemetry will ONLY be availabe if Advanced Auditing is enabled for the M365 user.
+    .DESCRIPTION
+        This function queries for searches performed in Exchange, providing visibility into what users are searching for and potential 
+        indications of insider threats or data exploration during incidents.
+    .PARAMETER UserPrincipalName
+        Specific user(s) to be investigated
+    .EXAMPLE
+        Get-HawkUserExchangeSearchQuery -UserPrincipalName bsmith@contoso.com
+        Returns search queries from Unified Audit Log (UAL) that correspond to the UserPrincipalName that is provided
+    .OUTPUTS
+        ExchangeSearchQueries_bsmith@contoso.com.csv /json
+        Simple_ExchangeSearchQueries_bsmith@contoso.com.csv/json
+    
+    .LINK
+        https://www.microsoft.com/security/blog/2020/12/21/advice-for-incident-responders-on-recovery-from-systemic-identity-compromises/
+    
+    .NOTES
+        "Operation Properties" and "Folders" will return "System.Object" as they are nested JSON within the AuditData field.
+        You will need to conduct individual log pull and review via PowerShell or other SIEM to determine values
+        for those fields.
+    #>
+        [CmdletBinding()]
+        param(
+            [Parameter(Mandatory=$true)]
+            [array]$UserPrincipalName
+        )
+    
+        BEGIN {
+            # Check if Hawk object exists and is fully initialized
+            if (Test-HawkGlobalObject) {
+                Initialize-HawkGlobalObject
+            }
+            Out-LogFile "Starting Unified Audit Log (UAL) search for 'SearchQueryInitiatedExchange'" -Action
+            Out-LogFile "Please be patient, this can take a while..." -Information
+            Test-EXOConnection
+        }#End Begin
+    
+        PROCESS {
+            
+            #Verify UPN input
+            [array]$UserArray = Test-UserObject -ToTest $UserPrincipalName
+    
+            foreach($UserObject in $UserArray) {
+                [string]$User = $UserObject.UserPrincipalName
+                
+                # Verify that user has operation enabled for auditing. Otherwise, move onto next user.
+                if (Test-OperationEnabled -User $User -Operation 'SearchQueryInitiated') {
+                    Out-LogFile "Operation 'SearchQueryInitiated' verified enabled for $User." -Information
+                    try {
+                        #Retrieve all audit data for mailitems accessed 
+                        $SearchCommand = "Search-UnifiedAuditLog -Operations 'SearchQueryInitiatedExchange' -UserIds $User"
+                        $ExchangeSearches = Get-AllUnifiedAuditLogEntry -UnifiedSearch $SearchCommand
+                        
+                        if ($ExchangeSearches.Count -gt 0){
+                            
+                            #Define output directory path for user
+                            $UserFolder = Join-Path -Path $Hawk.FilePath -ChildPath $User
+        
+                            #Create user directory if it doesn't already exist
+                            if (-not (Test-Path -Path $UserFolder)) {
+                                New-Item -Path $UserFolder -ItemType Directory -Force | Out-Null
+                            }
+        
+                            #Compress raw data into more simple view
+                            $ExchangeSearchesSimple = $ExchangeSearches | Get-SimpleUnifiedAuditLog
+        
+                            #Export both raw and simplistic views to specified user's folder
+                            $ExchangeSearches | Select-Object -ExpandProperty AuditData | Convertfrom-Json | Out-MultipleFileType -FilePrefix "ExchangeSearchQueries_$User" -User $User -csv -json
+                            $ExchangeSearchesSimple | Out-MultipleFileType -FilePrefix "Simple_ExchangeSearchQueries_$User" -User $User -csv -json
+                        } else {
+                            Out-LogFile "Get-HawkUserExchangeSearchQuery completed successfully" -Information
+                            Out-LogFile "No items found for $User." -Information
+                        }
+                    } catch {
+                        Out-LogFile "Error processing Exchange Search Queries for $User : $_" -isError
+                        Write-Error -ErrorRecord $_ -ErrorAction Continue
+                    }
+                } else {
+                    Out-LogFile "Operation 'SearchQueryInitiated' is not enabled for $User." -Information
+                    Out-LogFile "No data recorded for $User." -Information
+                }
+            }
+            
+        }#End Process
+    
+        END{
+            Out-Logfile "Completed exporting Search Query logs" -Information
+        }#End End
+    
+    }

--- a/Hawk/internal/functions/Test-OperationEnabled.ps1
+++ b/Hawk/internal/functions/Test-OperationEnabled.ps1
@@ -1,26 +1,25 @@
-<#
-.SYNOPSIS
-    Test if a user has a specific operation enabled for auditing
-.DESCRIPTION
-    Test if a user has a specific operation enabled for auditing
-.EXAMPLE
-    [bool]$result = Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
-.PARAMETER User
-    Specific user under investigation
-.PARAMETER Operation
-    Operation to be verified enabled for auditing
-.EXAMPLE
-    Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
-    Checks if the SearchQueryInitiated audit operation is enabled for user bsmith@contoso.com. Returns True if enabled, False if disabled.
-.OUTPUTS
-    System.Boolean
-    Output is a boolean result returned to the calling external function
-.NOTES
-    This function is internal and to be called from another Hawk user-enabled function.  Return value is boolean, and
-    it is intended to be used in an if-else check verifying an operation is enabled for auditing under a given user.
-#>
 Function Test-OperationEnabled {
-    
+    <#
+    .SYNOPSIS
+        Test if a user has a specific operation enabled for auditing
+    .DESCRIPTION
+        Test if a user has a specific operation enabled for auditing
+    .EXAMPLE
+        [bool]$result = Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
+    .PARAMETER User
+        Specific user under investigation
+    .PARAMETER Operation
+        Operation to be verified enabled for auditing
+    .EXAMPLE
+        Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
+        
+    .OUTPUTS
+        System.Boolean
+        Output is a boolean result returned to the calling external function
+    .NOTES
+        This function is internal and to be called from another Hawk user-enabled function.  Return value is boolean, and
+        it is intended to be used in an if-else check verifying an operation is enabled for auditing under a given user.
+    #>
     [CmdletBinding()]
     [OutputType([bool])]
     param(

--- a/Hawk/internal/functions/Test-OperationEnabled.ps1
+++ b/Hawk/internal/functions/Test-OperationEnabled.ps1
@@ -11,6 +11,7 @@
     Operation to be verified enabled for auditing
 .EXAMPLE
     Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
+    Checks if the SearchQueryInitiated audit operation is enabled for user bsmith@contoso.com. Returns True if enabled, False if disabled.
 .OUTPUTS
     System.Boolean
     Output is a boolean result returned to the calling external function

--- a/Hawk/internal/functions/Test-OperationEnabled.ps1
+++ b/Hawk/internal/functions/Test-OperationEnabled.ps1
@@ -1,24 +1,42 @@
 Function Test-OperationEnabled {
     <#
     .SYNOPSIS
-        Test if a user has a specific operation enabled for auditing
+        Tests if a specified audit operation is enabled for a given user.
+
     .DESCRIPTION
-        Test if a user has a specific operation enabled for auditing
-    .EXAMPLE
-        [bool]$result = Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
+        An internal helper function that verifies whether a specific audit operation 
+        is enabled in a user's mailbox auditing configuration. This function queries
+        the mailbox settings using Get-Mailbox and checks the AuditOwner property
+        for the specified operation.
+
     .PARAMETER User
-        Specific user under investigation
+        The UserPrincipalName of the user to check auditing configuration for.
+        
     .PARAMETER Operation
-        Operation to be verified enabled for auditing
+        The specific audit operation to check for (e.g., 'SearchQueryInitiated').
+
     .EXAMPLE
-        Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
-        Checks if the SearchQueryInitiated audit operation is enabled for user bsmith@contoso.com. Returns True if enabled, False if disabled.
+        $result = Test-OperationEnabled -User "user@contoso.com" -Operation "SearchQueryInitiated"
+        
+        Checks if the SearchQueryInitiated operation is enabled for user@contoso.com's mailbox.
+        Returns True if enabled, False if not enabled.
+
+    .EXAMPLE
+        if (Test-OperationEnabled -User $userUpn -Operation 'MailItemsAccessed') {
+            # Proceed with mail items access audit
+        }
+
+        Shows how to use the function in a conditional check before performing
+        an audit operation that requires specific permissions.
+
     .OUTPUTS
         System.Boolean
-        Output is a boolean result returned to the calling external function
+        Returns True if the operation is enabled for the user, False otherwise.
+
     .NOTES
-        This function is internal and to be called from another Hawk user-enabled function.  Return value is boolean, and
-        it is intended to be used in an if-else check verifying an operation is enabled for auditing under a given user.
+        Internal Function
+        Author: Jonathan Butler
+        Requirements: Exchange Online PowerShell session with appropriate permissions
     #>
     [CmdletBinding()]
     [OutputType([bool])]

--- a/Hawk/internal/functions/Test-OperationEnabled.ps1
+++ b/Hawk/internal/functions/Test-OperationEnabled.ps1
@@ -1,0 +1,40 @@
+<#
+.SYNOPSIS
+    Test if a user has a specific operation enabled for auditing
+.DESCRIPTION
+    Test if a user has a specific operation enabled for auditing
+.EXAMPLE
+    [bool]$result = Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
+.PARAMETER User
+    Specific user under investigation
+.PARAMETER Operation
+    Operation to be verified enabled for auditing
+.EXAMPLE
+    Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
+.OUTPUTS
+    System.Boolean
+    Output is a boolean result returned to the calling external function
+.NOTES
+    This function is internal and to be called from another Hawk user-enabled function.  Return value is boolean, and
+    it is intended to be used in an if-else check verifying an operation is enabled for auditing under a given user.
+#>
+Function Test-OperationEnabled {
+    
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$User,
+        [Parameter(Mandatory=$true)]
+        [string]$Operation
+    )
+
+    # Verify the provided User has the specified Operation enabled
+    $TestResult = Get-Mailbox -Identity $User | Where-Object -Property AuditOwner -eq $Operation
+
+    if ($null -eq $TestResult) {
+        return $false
+    } else {
+        return $true
+    }
+}

--- a/Hawk/internal/functions/Test-OperationEnabled.ps1
+++ b/Hawk/internal/functions/Test-OperationEnabled.ps1
@@ -12,7 +12,7 @@ Function Test-OperationEnabled {
         Operation to be verified enabled for auditing
     .EXAMPLE
         Test-OperationEnabled -User bsmith@contoso.com -Operation 'SearchQueryInitiated'
-        
+        Checks if the SearchQueryInitiated audit operation is enabled for user bsmith@contoso.com. Returns True if enabled, False if disabled.
     .OUTPUTS
         System.Boolean
         Output is a boolean result returned to the calling external function


### PR DESCRIPTION
# Pull Request Template

## Description

Created function Get-HawkUserExchangeSearchQuery to pull audit on operation 'SearchQueryInitiatedExchange'.  Additionally, an internal function Test-OperationEnabled was implemented to verify an operation is enabled for audit before attempting pull the associated logs.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
- [X] Unit test of Get-HawkUserExchangeSearchQuery and Get-HawkUserMailItemsAccessed to confirm expected output


## Checklist:

- [X] My code follows the style guidelines of Hawk
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
