### PR TITLE
Refactor code for readability and consistency, removed semicolons as line terminators

### DIFF
--- a/Hawk/internal/functions/Convert-ReportToHTML.ps1
+++ b/Hawk/internal/functions/Convert-ReportToHTML.ps1
@@ -41,9 +41,9 @@ Function Convert-ReportToHTML {
         $OutputFile = Join-Path (Split-path $xml) ((split-path $xml -Leaf).split(".")[0] + ".html")
 
         # Run the transform on the XML and produce the HTML
-        $xslt = New-Object System.Xml.Xsl.XslCompiledTransform;
-        $xslt.Load($xsl);
-        $xslt.Transform($xml, $OutputFile);
+        $xslt = New-Object System.Xml.Xsl.XslCompiledTransform
+        $xslt.Load($xsl)
+        $xslt.Transform($xml, $OutputFile)
     }
     end
     { }

--- a/Hawk/internal/functions/Start-SleepWithProgress.ps1
+++ b/Hawk/internal/functions/Start-SleepWithProgress.ps1
@@ -20,10 +20,10 @@ Function Start-SleepWithProgress {
 
     # Loop Number of seconds you want to sleep
     For ($i = 0; $i -le $sleeptime; $i++) {
-        $timeleft = ($sleeptime - $i);
+        $timeleft = ($sleeptime - $i)
 
         # Progress bar showing progress of the sleep
-        Write-Progress -Activity "Sleeping" -CurrentOperation "$Timeleft More Seconds" -PercentComplete (($i / $sleeptime) * 100);
+        Write-Progress -Activity "Sleeping" -CurrentOperation "$Timeleft More Seconds" -PercentComplete (($i / $sleeptime) * 100)
 
         # Sleep 1 second
         start-sleep 1

--- a/install.ps1
+++ b/install.ps1
@@ -270,7 +270,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 				$path
 			)
 
-			$result = $true;
+			$result = $true
 
 			# null and empty check are are already done on Path parameter at the cmdlet layer.
 			foreach ($currentPath in $path)
@@ -282,7 +282,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 				}
 			}
 
-			return $result;
+			return $result
 		}
 
 
@@ -1197,7 +1197,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 		$resolvedPaths = GetResolvedPathHelper $inputPaths $isLiteralPathUsed $PSCmdlet
 		IsValidFileSystemPath $resolvedPaths | Out-Null
 
-		$sourcePath = $resolvedPaths;
+		$sourcePath = $resolvedPaths
 
 		# CSVHelper: This is a helper function used to append comma after each path specifid by
 		# the $sourcePath array. The comma saperated paths are displayed in the -WhatIf message.
@@ -1416,7 +1416,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 				$path
 			)
 
-			$result = $true;
+			$result = $true
 
 			# null and empty check are are already done on Path parameter at the cmdlet layer.
 			foreach ($currentPath in $path)
@@ -1428,7 +1428,7 @@ PreparingToExpandVerboseMessage=Preparing to expand...
 				}
 			}
 
-			return $result;
+			return $result
 		}
 
 


### PR DESCRIPTION
Refactor code for readability and consistency using the following command:

```powershell
Invoke-ScriptAnalyzer -Settings .\Hawk\internal\configurations\PSScriptAnalyzerSettings.psd1 -Path .\ -Recurse -Fix -IncludeRule PSAvoidSemicolonsAsLineTerminators
```

- Removed unnecessary line breaks in `Convert-ReportToHTML.ps1` for streamlined XSLT transformation.
- Improved readability in `Start-SleepWithProgress.ps1` by removing semicolon terminator.
- Applied similar formatting improvements throughout `install.ps1` for cleaner code structure.