### PR TITLE
Fix EXO connection error handling for MSAL auth failures

### DIFF
--- a/Hawk/internal/functions/Test-EXOConnection.ps1
+++ b/Hawk/internal/functions/Test-EXOConnection.ps1
@@ -2,26 +2,43 @@
 .SYNOPSIS
     Test if we are connected to Exchange Online and connect if not
 .DESCRIPTION
-    Test if we are connected to Exchange Online and connect if not
+    Test if we are connected to Exchange Online and connect if not.
+    Catches all connection failures including expired sessions and
+    MSAL authentication errors, with a single retry before failing.
 .EXAMPLE
-    PS C:\> <example usage>
-    Explanation of what the example does
-.INPUTS
-    Inputs (if any)
+    PS C:\> Test-EXOConnection
+    Tests the current Exchange Online connection and reconnects if needed.
 .OUTPUTS
-    Output (if any)
+    None. Throws a terminating error if connection cannot be established.
 .NOTES
     General notes
 #>
 Function Test-EXOConnection {
     # In all cases make sure we are "connected" to EXO
     try {
-        $null = Get-OrganizationConfig -erroraction stop
+        $null = Get-OrganizationConfig -ErrorAction Stop
     }
-    catch [System.Management.Automation.CommandNotFoundException] {
-        # Connect to EXO if we couldn't find the command
+    catch {
+        # Connect to EXO if not connected or session is stale/expired
         Out-LogFile "Not Connected to Exchange Online" -Information
         Out-LogFile "Connecting to EXO using Exchange Online Module" -Action
-        Connect-ExchangeOnline
+
+        try {
+            Connect-ExchangeOnline -ErrorAction Stop
+        }
+        catch {
+            Out-LogFile "Initial EXO connection attempt failed: $($_.Exception.Message)" -Information
+            Out-LogFile "Retrying EXO connection..." -Action
+            try {
+                Connect-ExchangeOnline -ErrorAction Stop
+            }
+            catch {
+                $errorMessage = @(
+                    "Unable to connect to Exchange Online: $($_.Exception.Message)"
+                    "Please try running 'Connect-ExchangeOnline' manually before running Hawk."
+                )
+                Stop-PSFFunction -Message ($errorMessage -join "`n") -EnableException $true
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes `Test-EXOConnection` to catch **all** exceptions from `Get-OrganizationConfig`, not just `CommandNotFoundException` — this handles expired/stale sessions that previously fell through silently
- Wraps `Connect-ExchangeOnline` with error handling and a single retry for transient MSAL token acquisition errors (`MsalServiceException`)
- Provides a clear error message with the manual workaround if both connection attempts fail

## Problem
Users reported unhandled `MsalServiceException` crashes when Hawk auto-connected to Exchange Online (see #287). The root cause was that `Test-EXOConnection` only caught `CommandNotFoundException`, leaving MSAL authentication errors and stale session failures completely unhandled.

## Test plan
- [ ] Verify normal EXO connection flow still works when already connected
- [ ] Verify auto-connection works when not yet connected
- [ ] Verify retry logic handles transient MSAL failures gracefully
- [ ] Verify clear error message is shown when both attempts fail

Closes #287

https://claude.ai/code/session_01BnFujty83uF1tyubTjtmx4